### PR TITLE
Add a color change to the favorite and new fact buttons when hovered

### DIFF
--- a/src/components/Fact/Fact.css
+++ b/src/components/Fact/Fact.css
@@ -53,6 +53,11 @@
   margin-top: 4em;
 }
 
+.new-fact-btn:hover,
+.fav-card-btn:hover {
+  background-color: #1f7855;
+}
+
 @media (max-width: 1250px) {
   .fact,
   .fact-img {


### PR DESCRIPTION
This was a small change to test for recent ci file add on. I changed the background color of the buttons on the facts page to change when in a hovered state.